### PR TITLE
Change GTK2 link color

### DIFF
--- a/gtk-2.0/gtkrc
+++ b/gtk-2.0/gtkrc
@@ -1,6 +1,6 @@
 # Numix GTK Theme
 
-gtk-color-scheme = "bg_color:#e7e7e7\nfg_color:#555555\nbase_color:#f9f9f9\ntext_color:#333333\nselected_bg_color:#1a80b6\nselected_fg_color:#f9f9f9\ntooltip_bg_color:#f9f9f9\ntooltip_fg_color:#333333\ntitlebar_bg_color:#e7e7e7\ntitlebar_fg_color:#555555\nmenubar_bg_color:#e7e7e7\nmenubar_fg_color:#555555\ntoolbar_bg_color:#e7e7e7\ntoolbar_fg_color:#555555\nmenu_bg_color:#f9f9f9\nmenu_fg_color:#333333\npanel_bg_color:#e7e7e7\npanel_fg_color:#555555\nlink_color:#fc6f5d"
+gtk-color-scheme = "bg_color:#e7e7e7\nfg_color:#555555\nbase_color:#f9f9f9\ntext_color:#333333\nselected_bg_color:#1a80b6\nselected_fg_color:#f9f9f9\ntooltip_bg_color:#f9f9f9\ntooltip_fg_color:#333333\ntitlebar_bg_color:#e7e7e7\ntitlebar_fg_color:#555555\nmenubar_bg_color:#e7e7e7\nmenubar_fg_color:#555555\ntoolbar_bg_color:#e7e7e7\ntoolbar_fg_color:#555555\nmenu_bg_color:#f9f9f9\nmenu_fg_color:#333333\npanel_bg_color:#e7e7e7\npanel_fg_color:#555555\nlink_color:#1a80b6"
 
 # Default Style
 


### PR DESCRIPTION
I think #1a80b6 suits Numix-Frost better:
![pcmanfm_link_1a80b6](https://cloud.githubusercontent.com/assets/1032430/9136926/94e5cf22-3d1a-11e5-96a2-541885aac6d3.png)
